### PR TITLE
ship dev_properties with application

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ You can read all about trackr in our developer blog:
 * [File Downloads with AngularJS](http://blog.techdev.de/an-angularjs-directive-to-download-pdf-files/)
 * [Processes and Tools](http://blog.techdev.de/trackr-an-angularjs-app-with-a-java-8-backend-part-iii/)
 
-For the API documentation just go [here](http://techdev-solutions.github.io/trackr-api-documentation/getting_started.html)
+For the API documentation just go [here](http://techdev-solutions.github.io/trackr-api-documentation/getting_started.html).
+There is also a [Vagrant](https://www.vagrantup.com/) project building the whole application over [here](https://github.com/techdev-solutions/trackr-vagrant).

--- a/src/main/resources/application_dev.properties
+++ b/src/main/resources/application_dev.properties
@@ -1,1 +1,3 @@
 trackr.frontendUrl=http://localhost
+oauth.trackr-page.redirect_uris=http://localhost
+proxy.path=portal


### PR DESCRIPTION
I know that users should provide their own `dev_properties` but since not providing the properties usually leads to an error I think we can ship them with the application (and users can override them). As this only affects the dev profile I think it is safe to do so.

I also added a link to the Vagrant project.