### PR TITLE
Support PID File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# OS
+application.pid
+
 # gradle / Maven
 target/
 build/

--- a/application.yaml
+++ b/application.yaml
@@ -8,6 +8,8 @@ spring:
         active: in-memory-database,dev,granular-security,http-basic
 trackr:
     frontendUrl: http://localhost
+endpoints:
+    enabled: false
 
 ---
 spring:

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-mail"
     compile "org.springframework.boot:spring-boot-starter-integration"
     compile "org.springframework.boot:spring-boot-starter-security"
+    compile "org.springframework.boot:spring-boot-starter-actuator"
 
     // not included in boot
     compile "org.springframework.integration:spring-integration-mail:4.1.1.RELEASE"

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.context.ApplicationListener=\
+org.springframework.boot.actuate.system.ApplicationPidFileWriter


### PR DESCRIPTION
With this pull request, trackr will be able to create a PID file upon start called `application.pid` and stored within the directory the application is started from.

Now that trackr runs on Spring Boot we need a more robust way of starting and stopping the application, using dedicated shell scripts. This, however requires those scripts to be aware of the respective PID.

Spring Boot offers a listener for this: `org.springframework.boot.actuate.system.ApplicationPidFileWriter`which (unfortunately) depends on `spring-boot-actuator` so we have to pull in a new dependency just to write a PID file which is weird.

Actuator also autoconfigures a couple of endpoints (cf. http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-endpoints) which I disabled for the time being.

The reason why this request cannot be merged yet is that the tests no longer pass (pretty much all of them) - here is a representative stacktrace:

    Caused by: java.lang.IllegalArgumentException: Property 'dataSource' is required
	at org.springframework.jdbc.support.JdbcAccessor.afterPropertiesSet(JdbcAccessor.java:135)
	at org.springframework.jdbc.core.JdbcTemplate.<init>(JdbcTemplate.java:169)
	at org.springframework.boot.actuate.health.DataSourceHealthIndicator.<init>(DataSourceHealthIndicator.java:96)
	at org.springframework.boot.actuate.autoconfigure.HealthIndicatorAutoConfiguration$DataSourcesHealthIndicatorConfiguration.createDataSourceHealthIndicator(HealthIndicatorAutoConfiguration.java:139)
	at org.springframework.boot.actuate.autoconfigure.HealthIndicatorAutoConfiguration$DataSourcesHealthIndicatorConfiguration.dbHealthIndicator(HealthIndicatorAutoConfiguration.java:125)
	at org.springframework.boot.actuate.autoconfigure.HealthIndicatorAutoConfiguration$DataSourcesHealthIndicatorConfiguration$$EnhancerBySpringCGLIB$$3c0db023.CGLIB$dbHealthIndicator$0(<generated>)
	at org.springframework.boot.actuate.autoconfigure.HealthIndicatorAutoConfiguration$DataSourcesHealthIndicatorConfiguration$$EnhancerBySpringCGLIB$$3c0db023$$FastClassBySpringCGLIB$$44ad1a00.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228)
	at org.springframework.context.annotation.ConfigurationClassEnhancer$BeanMethodInterceptor.intercept(ConfigurationClassEnhancer.java:309)
	at org.springframework.boot.actuate.autoconfigure.HealthIndicatorAutoConfiguration$DataSourcesHealthIndicatorConfiguration$$EnhancerBySpringCGLIB$$3c0db023.dbHealthIndicator(<generated>)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:162)
	... 159 more

The bottom line is that the `DataSourceHealthIndicator` is missing a `DataSource` (cf. https://github.com/spring-projects/spring-boot/blob/master/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/DataSourceHealthIndicator.java#L96) which is strange enough since the corresponding autoconfiguration only kicks in if there is already a `DataSource` present in the context (cf. https://github.com/spring-projects/spring-boot/blob/master/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/autoconfigure/HealthIndicatorAutoConfiguration.java#L97).

By the way, the application runs just fine so maybe it is also an issue with the test config.

While these issues remain open this request should not be merged.