### PR TITLE
hook pid file into application lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# OS
+application.pid
+
 # gradle / Maven
 target/
 build/

--- a/src/main/java/de/techdev/trackr/Trackr.java
+++ b/src/main/java/de/techdev/trackr/Trackr.java
@@ -1,5 +1,6 @@
 package de.techdev.trackr;
 
+import org.springframework.boot.ApplicationPid;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
@@ -8,7 +9,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ImportResource;
 import org.springframework.context.annotation.Primary;
 
+import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
+import java.io.File;
+import java.io.IOException;
 
 @SpringBootApplication
 @ImportResource(value = "classpath:META-INF/mail-integration.xml")
@@ -19,6 +23,13 @@ public class Trackr {
     @ConfigurationProperties("spring.datasource")
     public DataSource primaryDataSource() {
         return DataSourceBuilder.create().build();
+    }
+
+    @PostConstruct
+    private void handlePid() throws IOException {
+        File file = new File("application.pid");
+        new ApplicationPid().write(file);
+        file.deleteOnExit();
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
with this pull request, trackr becomes able to write a PID file whenever the application starts, which is removed upon the application is stopped.

the approach is copied from the way Spring's very own `ApplicationPidFileWriter` works; but since this writer is part of `spring-boot-actuator` and thus pulls in a whole new dependency, the own implementation is more lightweight and only depends on `spring-boot` core.