### PR TITLE
Trackr remove lombok data

### DIFF
--- a/src/main/java/de/techdev/trackr/domain/company/Address.java
+++ b/src/main/java/de/techdev/trackr/domain/company/Address.java
@@ -2,7 +2,6 @@ package de.techdev.trackr.domain.company;
 
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.*;
@@ -13,7 +12,6 @@ import javax.persistence.*;
 @Entity
 @Getter
 @Setter
-@ToString
 public class Address {
 
     @Id

--- a/src/main/java/de/techdev/trackr/domain/company/Address.java
+++ b/src/main/java/de/techdev/trackr/domain/company/Address.java
@@ -1,6 +1,8 @@
 package de.techdev.trackr.domain.company;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.*;
@@ -9,7 +11,9 @@ import javax.persistence.*;
  * @author Moritz Schulze
  */
 @Entity
-@Data
+@Getter
+@Setter
+@ToString
 public class Address {
 
     @Id

--- a/src/main/java/de/techdev/trackr/domain/company/AddressEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/company/AddressEventHandler.java
@@ -1,6 +1,5 @@
 package de.techdev.trackr.domain.company;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.rest.core.annotation.HandleBeforeCreate;
 import org.springframework.data.rest.core.annotation.HandleBeforeDelete;
 import org.springframework.data.rest.core.annotation.HandleBeforeSave;
@@ -16,24 +15,21 @@ import org.springframework.security.access.prepost.PreAuthorize;
  * @author Moritz Schulze
  */
 @RepositoryEventHandler(Address.class)
-@Slf4j
+@SuppressWarnings("unused")
 public class AddressEventHandler {
 
     @HandleBeforeCreate
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void checkSaveAuthority(Address address) {
-        log.debug("Creating address {}", address);
     }
 
     @HandleBeforeSave
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void checkUpdateAuthority(Address address) {
-        log.debug("Updating address {}", address);
     }
 
     @HandleBeforeDelete
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void checkDeleteAuthority(Address address) {
-        log.debug("Deleting address {}", address);
     }
 }

--- a/src/main/java/de/techdev/trackr/domain/company/Company.java
+++ b/src/main/java/de/techdev/trackr/domain/company/Company.java
@@ -2,8 +2,9 @@ package de.techdev.trackr.domain.company;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import de.techdev.trackr.domain.project.Project;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.validator.constraints.NotEmpty;
 
@@ -16,7 +17,8 @@ import java.util.List;
 /**
  * @author Moritz Schulze
  */
-@Data
+@Getter
+@Setter
 @ToString(exclude = {"contactPersons", "address", "projects", "debitorProjects"})
 @EqualsAndHashCode(exclude = "contactPersons")
 @Entity

--- a/src/main/java/de/techdev/trackr/domain/company/Company.java
+++ b/src/main/java/de/techdev/trackr/domain/company/Company.java
@@ -5,7 +5,6 @@ import de.techdev.trackr.domain.project.Project;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.*;
@@ -19,7 +18,6 @@ import java.util.List;
  */
 @Getter
 @Setter
-@ToString(exclude = {"contactPersons", "address", "projects", "debitorProjects"})
 @EqualsAndHashCode(exclude = "contactPersons")
 @Entity
 @JsonIgnoreProperties({"debitorProjects"})

--- a/src/main/java/de/techdev/trackr/domain/company/CompanyEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/company/CompanyEventHandler.java
@@ -1,6 +1,5 @@
 package de.techdev.trackr.domain.company;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.rest.core.annotation.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 
@@ -10,36 +9,31 @@ import java.util.List;
  * @author Moritz Schulze
  */
 @RepositoryEventHandler(Company.class)
-@Slf4j
+@SuppressWarnings("unused")
 public class CompanyEventHandler {
 
     @HandleBeforeCreate
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void checkSaveAuthority(Company company) {
-        log.debug("Creating company {}", company);
     }
 
     @HandleBeforeSave
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void checkUpdateAuthority(Company company) {
-        log.debug("Updating company {}", company);
     }
 
     @HandleBeforeDelete
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void checkDeleteAuthority(Company company) {
-        log.debug("Deleting company {}", company);
     }
 
     @HandleBeforeLinkSave
     @PreAuthorize("hasRole('ROLE_SUPERVISOR')")
     public void beforeAddContactPerson(Company company, List<ContactPerson> contactPersons) {
-        log.debug("Adding contact persons {} to company {}", contactPersons, company);
     }
 
     @HandleBeforeLinkDelete
     @PreAuthorize("hasRole('ROLE_SUPERVISOR')")
     public void beforeDeleteContactPerson(Company company) {
-        log.debug("Deleting linked entity from company, is now {}", company);
     }
 }

--- a/src/main/java/de/techdev/trackr/domain/company/ContactPerson.java
+++ b/src/main/java/de/techdev/trackr/domain/company/ContactPerson.java
@@ -1,6 +1,7 @@
 package de.techdev.trackr.domain.company;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.NotEmpty;
@@ -12,7 +13,8 @@ import javax.validation.constraints.NotNull;
  * @author Moritz Schulze
  */
 @Entity
-@Data
+@Getter
+@Setter
 @ToString(exclude = {"company"})
 public class ContactPerson {
 

--- a/src/main/java/de/techdev/trackr/domain/company/ContactPerson.java
+++ b/src/main/java/de/techdev/trackr/domain/company/ContactPerson.java
@@ -2,7 +2,6 @@ package de.techdev.trackr.domain.company;
 
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.NotEmpty;
 
@@ -15,7 +14,6 @@ import javax.validation.constraints.NotNull;
 @Entity
 @Getter
 @Setter
-@ToString(exclude = {"company"})
 public class ContactPerson {
 
     @Id

--- a/src/main/java/de/techdev/trackr/domain/company/ContactPersonEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/company/ContactPersonEventHandler.java
@@ -1,6 +1,5 @@
 package de.techdev.trackr.domain.company;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.rest.core.annotation.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 
@@ -8,25 +7,22 @@ import org.springframework.security.access.prepost.PreAuthorize;
  * @author Moritz Schulze
  */
 @RepositoryEventHandler(ContactPerson.class)
-@Slf4j
+@SuppressWarnings("unused")
 public class ContactPersonEventHandler {
 
     @HandleBeforeCreate
     @PreAuthorize("hasRole('ROLE_SUPERVISOR')")
     public void checkCreateAuthority(ContactPerson contactPerson) {
-        log.debug("Creating contact person {}", contactPerson);
     }
 
     @HandleBeforeSave
     @PreAuthorize("hasRole('ROLE_SUPERVISOR')")
     public void checkUpdateAuthority(ContactPerson contactPerson) {
-        log.debug("Updating contact person {}", contactPerson);
     }
 
     @HandleBeforeDelete
     @PreAuthorize("hasRole('ROLE_SUPERVISOR')")
     public void checkDeleteAuthority(ContactPerson contactPerson) {
-        log.debug("Deleting contact person {}", contactPerson);
     }
 
     @HandleBeforeLinkSave

--- a/src/main/java/de/techdev/trackr/domain/employee/Employee.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/Employee.java
@@ -9,7 +9,6 @@ import de.techdev.trackr.domain.project.worktimes.WorkTime;
 import de.techdev.trackr.domain.validation.constraints.EndAfterBegin;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.NotEmpty;
 
@@ -26,7 +25,6 @@ import java.util.List;
 @Entity
 @Getter
 @Setter
-@ToString(exclude = {"workTimes", "billableTimes", "vacationRequests", "approvedRequests", "travelExpenseReports"})
 @JsonIgnoreProperties({"credential", "workTimes", "billableTimes", "vacationRequests", "approvedRequests", "travelExpenseReports"})
 @EndAfterBegin(begin = "joinDate", end = "leaveDate")
 public class Employee {

--- a/src/main/java/de/techdev/trackr/domain/employee/Employee.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/Employee.java
@@ -7,7 +7,8 @@ import de.techdev.trackr.domain.employee.vacation.VacationRequest;
 import de.techdev.trackr.domain.project.billtimes.BillableTime;
 import de.techdev.trackr.domain.project.worktimes.WorkTime;
 import de.techdev.trackr.domain.validation.constraints.EndAfterBegin;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.NotEmpty;
@@ -22,8 +23,9 @@ import java.util.List;
 /**
  * Represents any employee of techdev.
  */
-@Data
 @Entity
+@Getter
+@Setter
 @ToString(exclude = {"workTimes", "billableTimes", "vacationRequests", "approvedRequests", "travelExpenseReports"})
 @JsonIgnoreProperties({"credential", "workTimes", "billableTimes", "vacationRequests", "approvedRequests", "travelExpenseReports"})
 @EndAfterBegin(begin = "joinDate", end = "leaveDate")

--- a/src/main/java/de/techdev/trackr/domain/employee/EmployeeEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/EmployeeEventHandler.java
@@ -1,29 +1,25 @@
 package de.techdev.trackr.domain.employee;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.rest.core.annotation.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 
 @RepositoryEventHandler(Employee.class)
-@Slf4j
+@SuppressWarnings("unused")
 public class EmployeeEventHandler {
 
     @HandleBeforeCreate
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void checkCreateAuthority(Employee employee) {
-        log.debug("Creating employee {}", employee);
     }
 
     @HandleBeforeSave
     @PreAuthorize("hasRole('ROLE_SUPERVISOR')")
     public void checkUpdateAuthority(Employee employee) {
-        log.debug("Updating employee {}", employee);
     }
 
     @HandleBeforeDelete
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void checkDeleteAuthority(Employee employee) {
-        log.debug("Deleting employee {}", employee);
     }
 
     @HandleBeforeLinkDelete

--- a/src/main/java/de/techdev/trackr/domain/employee/SelfEmployee.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/SelfEmployee.java
@@ -1,6 +1,7 @@
 package de.techdev.trackr.domain.employee;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.validator.constraints.NotEmpty;
 
 /**
@@ -8,7 +9,8 @@ import org.hibernate.validator.constraints.NotEmpty;
  *
  * @author Moritz Schulze
  */
-@Data
+@Getter
+@Setter
 public class SelfEmployee {
 
     @NotEmpty

--- a/src/main/java/de/techdev/trackr/domain/employee/addressbook/ReducedEmployee.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/addressbook/ReducedEmployee.java
@@ -1,12 +1,14 @@
 package de.techdev.trackr.domain.employee.addressbook;
 
 import de.techdev.trackr.domain.employee.Employee;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Employee only containing the information needed for the address book.
  */
-@Data
+@Getter
+@Setter
 public class ReducedEmployee {
 
     private String firstName;

--- a/src/main/java/de/techdev/trackr/domain/employee/expenses/TravelExpense.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/expenses/TravelExpense.java
@@ -2,7 +2,8 @@ package de.techdev.trackr.domain.employee.expenses;
 
 import de.techdev.trackr.domain.employee.expenses.reports.Report;
 import de.techdev.trackr.domain.validation.constraints.EndAfterBegin;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 import javax.persistence.*;
@@ -13,7 +14,8 @@ import java.util.Date;
 /**
  * @author Moritz Schulze
  */
-@Data
+@Getter
+@Setter
 @ToString(exclude = "report")
 @Entity
 @EndAfterBegin(begin = "fromDate", end = "toDate")

--- a/src/main/java/de/techdev/trackr/domain/employee/expenses/TravelExpense.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/expenses/TravelExpense.java
@@ -4,7 +4,6 @@ import de.techdev.trackr.domain.employee.expenses.reports.Report;
 import de.techdev.trackr.domain.validation.constraints.EndAfterBegin;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -16,12 +15,11 @@ import java.util.Date;
  */
 @Getter
 @Setter
-@ToString(exclude = "report")
 @Entity
 @EndAfterBegin(begin = "fromDate", end = "toDate")
 public class TravelExpense {
 
-    public static enum Type {
+    public enum Type {
         HOTEL, TAXI, FLIGHT, TRAIN, PARKING, OEPNV, MILEAGE_ALLOWANCE, OTHER
     }
 

--- a/src/main/java/de/techdev/trackr/domain/employee/expenses/TravelExpenseEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/expenses/TravelExpenseEventHandler.java
@@ -1,30 +1,26 @@
 package de.techdev.trackr.domain.employee.expenses;
 
 import de.techdev.trackr.domain.employee.expenses.reports.Report;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.rest.core.annotation.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 
 @RepositoryEventHandler(TravelExpense.class)
-@Slf4j
+@SuppressWarnings("unused")
 public class TravelExpenseEventHandler {
 
     @HandleBeforeCreate
     @PreAuthorize("@travelExpenseEventHandler.canCreate(principal?.username, #travelExpense)")
     public void checkCreateAuthority(TravelExpense travelExpense) {
-        log.debug("Creating travel expense {}", travelExpense);
     }
 
     @HandleBeforeSave
     @PreAuthorize("hasRole('ROLE_SUPERVISOR') or @travelExpenseEventHandler.canEdit(principal?.username, #travelExpense)")
     public void checkUpdateAuthority(TravelExpense travelExpense) {
-        log.debug("Updating travel expense {}", travelExpense);
     }
 
     @HandleBeforeDelete
     @PreAuthorize("hasRole('ROLE_SUPERVISOR') or @travelExpenseEventHandler.canDelete(principal?.username, #travelExpense)")
     public void checkDeleteAuthority(TravelExpense travelExpense) {
-        log.debug("Deleting travel expense {}", travelExpense);
     }
 
     @HandleBeforeLinkSave

--- a/src/main/java/de/techdev/trackr/domain/employee/expenses/reports/Report.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/expenses/reports/Report.java
@@ -8,7 +8,6 @@ import de.techdev.trackr.domain.project.Project;
 import de.techdev.trackr.domain.validation.constraints.ProjectBelongsToCompany;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -22,11 +21,10 @@ import java.util.List;
 @Setter
 @Entity
 @Table(name = "travelExpenseReport")
-@ToString(exclude = {"expenses", "employee", "approver", "comments"})
 @ProjectBelongsToCompany(companyField = "debitor")
 public class Report {
 
-    public static enum Status {
+    public enum Status {
         SUBMITTED, PENDING, APPROVED, REJECTED
     }
 

--- a/src/main/java/de/techdev/trackr/domain/employee/expenses/reports/Report.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/expenses/reports/Report.java
@@ -6,7 +6,8 @@ import de.techdev.trackr.domain.employee.expenses.TravelExpense;
 import de.techdev.trackr.domain.employee.expenses.reports.comments.Comment;
 import de.techdev.trackr.domain.project.Project;
 import de.techdev.trackr.domain.validation.constraints.ProjectBelongsToCompany;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 import javax.persistence.*;
@@ -17,7 +18,8 @@ import java.util.List;
 /**
  * @author Moritz Schulze
  */
-@Data
+@Getter
+@Setter
 @Entity
 @Table(name = "travelExpenseReport")
 @ToString(exclude = {"expenses", "employee", "approver", "comments"})

--- a/src/main/java/de/techdev/trackr/domain/employee/expenses/reports/ReportEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/expenses/reports/ReportEventHandler.java
@@ -1,31 +1,27 @@
 package de.techdev.trackr.domain.employee.expenses.reports;
 
 import de.techdev.trackr.domain.employee.Employee;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.rest.core.annotation.*;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 
 @RepositoryEventHandler(Report.class)
-@Slf4j
+@SuppressWarnings("unused")
 public class ReportEventHandler {
 
     @HandleBeforeCreate
     @PreAuthorize("#travelExpenseReport.employee.email == principal?.username")
     public void checkCreateAuthority(Report travelExpenseReport) {
-        log.debug("Creating travel expense report {}", travelExpenseReport);
     }
 
     @HandleBeforeSave
     @PreAuthorize("hasRole('ROLE_SUPERVISOR')")
     public void checkUpdateAuthority(Report travelExpenseReport) {
-        log.debug("Updating travel expense report {}", travelExpenseReport);
     }
 
     @HandleBeforeDelete
     @PreAuthorize("@reportEventHandler.employeeCanDeleteReport(#travelExpenseReport, principal?.username) or hasRole('ROLE_ADMIN')")
     public void checkDeleteAuthority(Report travelExpenseReport) {
-        log.debug("Deleting travel expense report {}", travelExpenseReport);
     }
 
     @HandleBeforeLinkSave

--- a/src/main/java/de/techdev/trackr/domain/employee/expenses/reports/comments/Comment.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/expenses/reports/comments/Comment.java
@@ -2,7 +2,9 @@ package de.techdev.trackr.domain.employee.expenses.reports.comments;
 
 import de.techdev.trackr.domain.employee.Employee;
 import de.techdev.trackr.domain.employee.expenses.reports.Report;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.*;
@@ -13,7 +15,9 @@ import java.util.Date;
  * @author Moritz Schulze
  */
 @Entity
-@Data
+@Getter
+@Setter
+@ToString
 @Table(name = "travelExpenseReportComment")
 public class Comment {
 

--- a/src/main/java/de/techdev/trackr/domain/employee/expenses/reports/comments/Comment.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/expenses/reports/comments/Comment.java
@@ -4,7 +4,6 @@ import de.techdev.trackr.domain.employee.Employee;
 import de.techdev.trackr.domain.employee.expenses.reports.Report;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.*;
@@ -17,7 +16,6 @@ import java.util.Date;
 @Entity
 @Getter
 @Setter
-@ToString
 @Table(name = "travelExpenseReportComment")
 public class Comment {
 

--- a/src/main/java/de/techdev/trackr/domain/employee/expenses/reports/comments/CommentEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/expenses/reports/comments/CommentEventHandler.java
@@ -1,20 +1,18 @@
 package de.techdev.trackr.domain.employee.expenses.reports.comments;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.rest.core.annotation.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 
 import java.util.Date;
 
 @RepositoryEventHandler(value = Comment.class)
-@Slf4j
+@SuppressWarnings("unused")
 public class CommentEventHandler {
 
     @HandleBeforeCreate
     @PreAuthorize("hasRole('ROLE_SUPERVISOR') or #comment.employee.email == principal?.username")
     public void checkCreateAuthority(Comment comment) {
         comment.setSubmissionDate(new Date());
-        log.debug("Creating comment {}", comment);
     }
 
     @HandleBeforeSave

--- a/src/main/java/de/techdev/trackr/domain/employee/login/PrincipalController.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/login/PrincipalController.java
@@ -5,7 +5,8 @@ import de.techdev.trackr.domain.employee.EmployeeRepository;
 import de.techdev.trackr.domain.employee.settings.Settings;
 import de.techdev.trackr.domain.employee.settings.SettingsRepository;
 import de.techdev.trackr.domain.employee.settings.SettingsType;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -22,7 +23,8 @@ import java.util.Collection;
 @Slf4j
 public class PrincipalController {
 
-    @Data
+    @Getter
+    @Setter
     static class ReturnValue {
         Collection<? extends GrantedAuthority> authorities;
         String locale;

--- a/src/main/java/de/techdev/trackr/domain/employee/settings/Settings.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/settings/Settings.java
@@ -1,14 +1,16 @@
 package de.techdev.trackr.domain.employee.settings;
 
 import de.techdev.trackr.domain.employee.Employee;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 
 @Entity
-@Data
+@Getter
+@Setter
 @Table( uniqueConstraints = { @UniqueConstraint(columnNames = {"type", "employee_id"}) } )
 public class Settings {
 

--- a/src/main/java/de/techdev/trackr/domain/employee/sickdays/SickDays.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/sickdays/SickDays.java
@@ -4,7 +4,6 @@ import de.techdev.trackr.domain.employee.Employee;
 import de.techdev.trackr.domain.validation.constraints.EndAfterBegin;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -16,7 +15,6 @@ import java.util.Date;
 @Entity
 @Getter
 @Setter
-@ToString
 @EndAfterBegin(begin = "startDate", end = "endDate")
 public class SickDays {
 

--- a/src/main/java/de/techdev/trackr/domain/employee/sickdays/SickDays.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/sickdays/SickDays.java
@@ -2,7 +2,9 @@ package de.techdev.trackr.domain.employee.sickdays;
 
 import de.techdev.trackr.domain.employee.Employee;
 import de.techdev.trackr.domain.validation.constraints.EndAfterBegin;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -12,7 +14,9 @@ import java.util.Date;
  * @author Moritz Schulze
  */
 @Entity
-@Data
+@Getter
+@Setter
+@ToString
 @EndAfterBegin(begin = "startDate", end = "endDate")
 public class SickDays {
 

--- a/src/main/java/de/techdev/trackr/domain/employee/sickdays/SickDaysEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/sickdays/SickDaysEventHandler.java
@@ -1,12 +1,11 @@
 package de.techdev.trackr.domain.employee.sickdays;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.core.annotation.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 
 @RepositoryEventHandler(value = SickDays.class)
-@Slf4j
+@SuppressWarnings("unused")
 public class SickDaysEventHandler {
 
     @Autowired
@@ -15,21 +14,18 @@ public class SickDaysEventHandler {
     @HandleBeforeCreate
     @PreAuthorize("#sickDays.employee.email == principal?.username or hasRole('ROLE_ADMIN')")
     public void checkSaveAuthority(SickDays sickDays) {
-        log.debug("Creating sickdays {}", sickDays);
         sickDaysNotifyService.notifySupervisorsAboutNew(sickDays);
     }
 
     @HandleBeforeSave
     @PreAuthorize("#sickDays.employee.email == principal?.username or hasRole('ROLE_ADMIN')")
     public void checkUpdateAuthority(SickDays sickDays) {
-        log.debug("Updating sickDays {}", sickDays);
         sickDaysNotifyService.notifySupervisorsAboutUpdate(sickDays);
     }
 
     @HandleBeforeDelete
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void checkDeleteAuthority(SickDays sickDays) {
-        log.debug("Deleting sickDays {}", sickDays);
     }
 
     @HandleBeforeLinkSave

--- a/src/main/java/de/techdev/trackr/domain/employee/vacation/Holiday.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/vacation/Holiday.java
@@ -1,7 +1,8 @@
 package de.techdev.trackr.domain.employee.vacation;
 
 import de.techdev.trackr.domain.common.FederalState;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 import javax.persistence.*;
 import java.util.Date;
@@ -10,7 +11,8 @@ import java.util.Date;
  * @author Moritz Schulze
  */
 @Entity
-@Data
+@Getter
+@Setter
 public class Holiday {
 
     @Id

--- a/src/main/java/de/techdev/trackr/domain/employee/vacation/VacationRequest.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/vacation/VacationRequest.java
@@ -5,7 +5,6 @@ import de.techdev.trackr.domain.employee.Employee;
 import de.techdev.trackr.domain.validation.constraints.EndAfterBegin;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -18,10 +17,9 @@ import java.util.Date;
 @Getter
 @Setter
 @EndAfterBegin(begin = "startDate", end = "endDate")
-@ToString(exclude = {"employee"})
 public class VacationRequest {
 
-    public static enum VacationRequestStatus {
+    public enum VacationRequestStatus {
         APPROVED, PENDING, REJECTED
     }
 

--- a/src/main/java/de/techdev/trackr/domain/employee/vacation/VacationRequest.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/vacation/VacationRequest.java
@@ -3,7 +3,8 @@ package de.techdev.trackr.domain.employee.vacation;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import de.techdev.trackr.domain.employee.Employee;
 import de.techdev.trackr.domain.validation.constraints.EndAfterBegin;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 import javax.persistence.*;
@@ -14,7 +15,8 @@ import java.util.Date;
  * @author Moritz Schulze
  */
 @Entity
-@Data
+@Getter
+@Setter
 @EndAfterBegin(begin = "startDate", end = "endDate")
 @ToString(exclude = {"employee"})
 public class VacationRequest {

--- a/src/main/java/de/techdev/trackr/domain/employee/vacation/VacationRequestEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/vacation/VacationRequestEventHandler.java
@@ -2,7 +2,6 @@ package de.techdev.trackr.domain.employee.vacation;
 
 import de.techdev.trackr.domain.common.UuidMapper;
 import de.techdev.trackr.domain.employee.vacation.support.VacationRequestNotifyService;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.core.annotation.*;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -11,7 +10,7 @@ import java.util.Date;
 import java.util.UUID;
 
 @RepositoryEventHandler(VacationRequest.class)
-@Slf4j
+@SuppressWarnings("unused")
 public class VacationRequestEventHandler {
 
     @Autowired
@@ -34,7 +33,6 @@ public class VacationRequestEventHandler {
         vacationRequest.setApprover(null);
         vacationRequest.setApprovalDate(null);
         vacationRequest.setSubmissionTime(new Date());
-        log.debug("Creating vacation request {}", vacationRequest);
     }
 
     @HandleAfterCreate
@@ -46,14 +44,12 @@ public class VacationRequestEventHandler {
     @HandleBeforeSave
     @PreAuthorize("hasRole('ROLE_SUPERVISOR') and principal?.username != #vacationRequest.employee.email")
     public void authorizeUpdate(VacationRequest vacationRequest) {
-        log.debug("Updating vacation request {}", vacationRequest);
     }
 
     @HandleBeforeDelete
     @PreAuthorize("( hasRole('ROLE_SUPERVISOR') and @vacationRequestEventHandler.supervisorCanDeleteRequest(principal?.username, #vacationRequest) ) " +
             "or @vacationRequestEventHandler.employeeCanDeleteRequest(principal?.username, #vacationRequest)")
     public void authorizeDelete(VacationRequest vacationRequest) {
-        log.debug("Deleting vacation request {}", vacationRequest);
     }
 
     @HandleBeforeLinkSave

--- a/src/main/java/de/techdev/trackr/domain/project/Project.java
+++ b/src/main/java/de/techdev/trackr/domain/project/Project.java
@@ -4,7 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import de.techdev.trackr.domain.company.Company;
 import de.techdev.trackr.domain.project.billtimes.BillableTime;
 import de.techdev.trackr.domain.project.worktimes.WorkTime;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.validator.constraints.NotEmpty;
 
@@ -18,7 +19,8 @@ import java.util.List;
  * @author Moritz Schulze
  */
 @Entity
-@Data
+@Getter
+@Setter
 @ToString(exclude = {"company", "debitor", "workTimes", "billableTimes"})
 @JsonIgnoreProperties({"workTimes", "billableTimes"})
 public class Project {

--- a/src/main/java/de/techdev/trackr/domain/project/Project.java
+++ b/src/main/java/de/techdev/trackr/domain/project/Project.java
@@ -6,7 +6,6 @@ import de.techdev.trackr.domain.project.billtimes.BillableTime;
 import de.techdev.trackr.domain.project.worktimes.WorkTime;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.*;
@@ -21,7 +20,6 @@ import java.util.List;
 @Entity
 @Getter
 @Setter
-@ToString(exclude = {"company", "debitor", "workTimes", "billableTimes"})
 @JsonIgnoreProperties({"workTimes", "billableTimes"})
 public class Project {
 

--- a/src/main/java/de/techdev/trackr/domain/project/ProjectEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/project/ProjectEventHandler.java
@@ -1,6 +1,5 @@
 package de.techdev.trackr.domain.project;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.rest.core.annotation.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 
@@ -8,36 +7,31 @@ import org.springframework.security.access.prepost.PreAuthorize;
  * @author Moritz Schulze
  */
 @RepositoryEventHandler(Project.class)
-@Slf4j
+@SuppressWarnings("unused")
 public class ProjectEventHandler {
 
     @HandleBeforeSave
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void checkUpdatePermission(Project project) {
-        log.debug("Updating project {}", project);
     }
 
     @HandleBeforeCreate
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void checkCreatePermission(Project project) {
-        log.debug("Creating project {}", project);
     }
 
     @HandleBeforeDelete
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void checkDeletePermission(Project project) {
-        log.debug("Deleting project {}", project);
     }
 
     @HandleBeforeLinkSave
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void checkCompanyPermission(Project project, Object link) {
-        log.debug("Changing links on project {}", project);
     }
 
     @HandleBeforeLinkDelete
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void checkLinkDeletePermission(Project project) {
-        log.debug("Deleting link from project {}", project);
     }
 }

--- a/src/main/java/de/techdev/trackr/domain/project/billtimes/BillableTime.java
+++ b/src/main/java/de/techdev/trackr/domain/project/billtimes/BillableTime.java
@@ -4,7 +4,6 @@ import de.techdev.trackr.domain.employee.Employee;
 import de.techdev.trackr.domain.project.Project;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 
 import javax.persistence.*;
 import javax.validation.constraints.Min;
@@ -17,7 +16,6 @@ import java.util.Date;
 @Entity
 @Getter
 @Setter
-@ToString(exclude = {"employee", "project"})
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"employee", "project", "date"}))
 public class BillableTime {
 

--- a/src/main/java/de/techdev/trackr/domain/project/billtimes/BillableTime.java
+++ b/src/main/java/de/techdev/trackr/domain/project/billtimes/BillableTime.java
@@ -2,7 +2,8 @@ package de.techdev.trackr.domain.project.billtimes;
 
 import de.techdev.trackr.domain.employee.Employee;
 import de.techdev.trackr.domain.project.Project;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 import javax.persistence.*;
@@ -14,7 +15,8 @@ import java.util.Date;
  * @author Moritz Schulze
  */
 @Entity
-@Data
+@Getter
+@Setter
 @ToString(exclude = {"employee", "project"})
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"employee", "project", "date"}))
 public class BillableTime {

--- a/src/main/java/de/techdev/trackr/domain/project/billtimes/BillableTimeEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/project/billtimes/BillableTimeEventHandler.java
@@ -1,6 +1,5 @@
 package de.techdev.trackr.domain.project.billtimes;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.rest.core.annotation.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 
@@ -8,36 +7,31 @@ import org.springframework.security.access.prepost.PreAuthorize;
  * @author Moritz Schulze
  */
 @RepositoryEventHandler(BillableTime.class)
-@Slf4j
+@SuppressWarnings("unused")
 public class BillableTimeEventHandler {
 
     @HandleBeforeCreate
     @PreAuthorize("hasRole('ROLE_SUPERVISOR')")
     public void checkCreateAuthority(BillableTime billableTime) {
-        log.debug("Creating billable time {}", billableTime);
     }
 
     @HandleBeforeSave
     @PreAuthorize("hasRole('ROLE_SUPERVISOR')")
     public void checkUpdateAuthority(BillableTime billableTime) {
-        log.debug("Updating billable time {}", billableTime);
     }
 
     @HandleBeforeDelete
     @PreAuthorize("hasRole('ROLE_SUPERVISOR')")
     public void checkDeleteAuthority(BillableTime billableTime) {
-        log.debug("Deleting billable time {}", billableTime);
     }
 
     @HandleBeforeLinkSave
     @PreAuthorize("hasRole('ROLE_SUPERVISOR')")
     public void checkLinkSaveAuthority(BillableTime billableTime, Object links) {
-        log.debug("Updating links on billable time {}", billableTime);
     }
 
     @HandleBeforeLinkDelete
     @PreAuthorize("denyAll()")
     public void checkLinkDeleteAuthority(BillableTime billableTime) {
-        log.debug("Deleting links on {}", billableTime);
     }
 }

--- a/src/main/java/de/techdev/trackr/domain/project/invoice/Invoice.java
+++ b/src/main/java/de/techdev/trackr/domain/project/invoice/Invoice.java
@@ -3,7 +3,6 @@ package de.techdev.trackr.domain.project.invoice;
 import de.techdev.trackr.domain.company.Company;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.*;
@@ -16,10 +15,9 @@ import java.util.Date;
 @Getter
 @Setter
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = "identifier"))
-@ToString(exclude = "debitor")
 public class Invoice {
 
-    public static enum InvoiceState {
+    public enum InvoiceState {
         OUTSTANDING, PAID, OVERDUE
     }
 

--- a/src/main/java/de/techdev/trackr/domain/project/invoice/Invoice.java
+++ b/src/main/java/de/techdev/trackr/domain/project/invoice/Invoice.java
@@ -1,7 +1,8 @@
 package de.techdev.trackr.domain.project.invoice;
 
 import de.techdev.trackr.domain.company.Company;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.validator.constraints.NotEmpty;
 
@@ -12,7 +13,8 @@ import java.math.BigDecimal;
 import java.util.Date;
 
 @Entity
-@Data
+@Getter
+@Setter
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = "identifier"))
 @ToString(exclude = "debitor")
 public class Invoice {

--- a/src/main/java/de/techdev/trackr/domain/project/invoice/InvoiceEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/project/invoice/InvoiceEventHandler.java
@@ -2,7 +2,6 @@ package de.techdev.trackr.domain.project.invoice;
 
 import de.techdev.trackr.domain.company.Company;
 import de.techdev.trackr.util.LocalDateUtil;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.rest.core.annotation.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 
@@ -14,7 +13,7 @@ import static de.techdev.trackr.util.LocalDateUtil.fromLocalDate;
  * @author Moritz Schulze
  */
 @RepositoryEventHandler(Invoice.class)
-@Slf4j
+@SuppressWarnings("unused")
 public class InvoiceEventHandler {
 
     @HandleBeforeCreate
@@ -22,7 +21,6 @@ public class InvoiceEventHandler {
     public void authorizeCreate(Invoice invoice) {
         setDueDateFromTimeForPayment(invoice);
         setInvoiceStateIfNecessary(invoice);
-        log.debug("Creating invoice {}", invoice);
     }
 
     @HandleBeforeSave
@@ -30,13 +28,11 @@ public class InvoiceEventHandler {
     public void authorizeUpdate(Invoice invoice) {
         setDueDateFromTimeForPayment(invoice);
         setInvoiceStateIfNecessary(invoice);
-        log.debug("Updating invoice {}", invoice);
     }
 
     @HandleBeforeDelete
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public void authorizeDelete(Invoice invoice) {
-        log.debug("Deleting invoice {}", invoice);
     }
 
     @HandleBeforeLinkSave

--- a/src/main/java/de/techdev/trackr/domain/project/worktimes/WorkTime.java
+++ b/src/main/java/de/techdev/trackr/domain/project/worktimes/WorkTime.java
@@ -3,7 +3,8 @@ package de.techdev.trackr.domain.project.worktimes;
 import de.techdev.trackr.domain.employee.Employee;
 import de.techdev.trackr.domain.project.Project;
 import de.techdev.trackr.domain.validation.constraints.EndAfterBegin;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 import javax.persistence.*;
@@ -15,7 +16,8 @@ import java.util.Date;
  * @author Moritz Schulze
  */
 @Entity
-@Data
+@Getter
+@Setter
 @ToString(exclude = {"employee", "project"})
 @EndAfterBegin(begin = "startTime", end = "endTime")
 public class WorkTime {

--- a/src/main/java/de/techdev/trackr/domain/project/worktimes/WorkTime.java
+++ b/src/main/java/de/techdev/trackr/domain/project/worktimes/WorkTime.java
@@ -5,7 +5,6 @@ import de.techdev.trackr.domain.project.Project;
 import de.techdev.trackr.domain.validation.constraints.EndAfterBegin;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -18,7 +17,6 @@ import java.util.Date;
 @Entity
 @Getter
 @Setter
-@ToString(exclude = {"employee", "project"})
 @EndAfterBegin(begin = "startTime", end = "endTime")
 public class WorkTime {
 

--- a/src/main/java/de/techdev/trackr/domain/project/worktimes/WorkTimeEmployee.java
+++ b/src/main/java/de/techdev/trackr/domain/project/worktimes/WorkTimeEmployee.java
@@ -2,23 +2,22 @@ package de.techdev.trackr.domain.project.worktimes;
 
 import de.techdev.trackr.domain.employee.Employee;
 import de.techdev.trackr.domain.project.billtimes.BillableTime;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.hateoas.ResourceSupport;
 
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.reducing;
-
 /**
  * DTO that contains only the needed information for the method findEmployeeMappingByProjectAndDateBetween.
  * <p>
  * It extends {@link org.springframework.hateoas.ResourceSupport} so a link to the employee entity can be added.
  */
-@Data
+@Getter
+@Setter
 @EqualsAndHashCode(callSuper = false)
 public class WorkTimeEmployee extends ResourceSupport {
     private String name;

--- a/src/main/java/de/techdev/trackr/domain/project/worktimes/WorkTimeEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/project/worktimes/WorkTimeEventHandler.java
@@ -1,31 +1,27 @@
 package de.techdev.trackr.domain.project.worktimes;
 
 import de.techdev.trackr.domain.employee.Employee;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.rest.core.annotation.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 
 @RepositoryEventHandler(WorkTime.class)
-@Slf4j
+@SuppressWarnings("unused")
 public class WorkTimeEventHandler {
 
     @HandleBeforeCreate
     @PreAuthorize("#workTime.employee.email == principal?.username")
     public void checkCreateAuthority(WorkTime workTime) {
-        log.debug("Creating work time {}", workTime);
     }
 
     @HandleBeforeSave
     @PreAuthorize("hasRole('ROLE_ADMIN') or #workTime.employee.email == principal?.username")
     public void checkUpdateAuthority(WorkTime workTime) {
-        log.debug("Updating work time {}", workTime);
     }
 
     @HandleBeforeDelete
     @PreAuthorize("hasRole('ROLE_ADMIN') or #workTime.employee.email == principal?.username")
     public void checkDeleteAuthority(WorkTime workTime) {
-        log.debug("Deleting work time {}", workTime);
     }
 
     @HandleBeforeLinkSave
@@ -34,7 +30,6 @@ public class WorkTimeEventHandler {
         if(Employee.class.isAssignableFrom(link.getClass())) {
             throw new HttpRequestMethodNotSupportedException("POST", new String[0]);
         }
-        log.debug("Updating links {} in work time {}", link, workTime);
     }
 
     @HandleBeforeLinkDelete


### PR DESCRIPTION
This pull requests removes all @Data annotation from entities and replaces them with @Getter and @Setter. This
a) improves the Sonar reports because the generated equals and hashcode were pretty untested
b) is actually more correct, since equals and hashcode based on all fields for entities might not be what we want. Also equals and hashcode were seldom/never used.