### PR TITLE
Fix naming for InvoiceOverdueService

### DIFF
--- a/src/main/java/de/techdev/trackr/domain/ApiBeansConfiguration.java
+++ b/src/main/java/de/techdev/trackr/domain/ApiBeansConfiguration.java
@@ -64,7 +64,7 @@ public class ApiBeansConfiguration {
     }
 
     @Bean
-    public InvoiceOverdueService invoiceOverduer() {
+    public InvoiceOverdueService invoiceOverdueService() {
         return new InvoiceOverdueService();
     }
 


### PR DESCRIPTION
Just a minor naming thing - shouldn't break anything... hopefully.