### PR TITLE
Remove unnecessary OneToMany associations

### DIFF
--- a/src/main/java/de/techdev/trackr/domain/employee/Employee.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/Employee.java
@@ -1,11 +1,6 @@
 package de.techdev.trackr.domain.employee;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import de.techdev.trackr.domain.common.FederalState;
-import de.techdev.trackr.domain.employee.expenses.reports.Report;
-import de.techdev.trackr.domain.employee.vacation.VacationRequest;
-import de.techdev.trackr.domain.project.billtimes.BillableTime;
-import de.techdev.trackr.domain.project.worktimes.WorkTime;
 import de.techdev.trackr.domain.validation.constraints.EndAfterBegin;
 import lombok.Getter;
 import lombok.Setter;
@@ -15,9 +10,7 @@ import org.hibernate.validator.constraints.NotEmpty;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 
 /**
  * Represents any employee of techdev.
@@ -25,7 +18,6 @@ import java.util.List;
 @Entity
 @Getter
 @Setter
-@JsonIgnoreProperties({"credential", "workTimes", "billableTimes", "vacationRequests", "approvedRequests", "travelExpenseReports"})
 @EndAfterBegin(begin = "joinDate", end = "leaveDate")
 public class Employee {
 
@@ -66,21 +58,6 @@ public class Employee {
     private FederalState federalState;
 
     private Float vacationEntitlement;
-
-    @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "employee")
-    private List<WorkTime> workTimes = new ArrayList<>();
-
-    @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "employee")
-    private List<BillableTime> billableTimes = new ArrayList<>();
-
-    @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "employee")
-    private List<VacationRequest> vacationRequests;
-
-    @OneToMany(mappedBy = "approver")
-    private List<VacationRequest> approvedRequests;
-
-    @OneToMany(mappedBy = "employee")
-    private List<Report> travelExpenseReports;
 
     public String fullName() {
         return getFirstName() + " " + getLastName();


### PR DESCRIPTION
They are mostly for cascading deletes. Since we won't really delete employees this is not necessary in this way. It also removes a lot of circular dependencies in Sonar.
