### PR TITLE
TRACKR-297 Upgrades to Spring Boot 1.3.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.2.1.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.3.3.RELEASE")
     }
 }
 
@@ -27,6 +27,10 @@ repositories {
     mavenCentral()
 }
 
+springBoot {
+    executable = true
+}
+
 dependencies {
     compile "org.springframework.boot:spring-boot-starter-data-rest"
     compile "org.springframework.boot:spring-boot-starter-data-jpa"
@@ -35,7 +39,7 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-security"
 
     // not included in boot
-    compile "org.springframework.integration:spring-integration-mail:4.1.1.RELEASE"
+    compile "org.springframework.integration:spring-integration-mail:4.2.5.RELEASE"
     compile "org.springframework.security.oauth:spring-security-oauth2:2.0.2.RELEASE"
 
     compile "com.h2database:h2"

--- a/src/main/java/de/techdev/trackr/core/web/api/ApiRepositoryRestConfiguration.java
+++ b/src/main/java/de/techdev/trackr/core/web/api/ApiRepositoryRestConfiguration.java
@@ -1,0 +1,79 @@
+package de.techdev.trackr.core.web.api;
+
+import de.techdev.trackr.core.web.converters.DateConverter;
+import de.techdev.trackr.domain.company.Address;
+import de.techdev.trackr.domain.company.Company;
+import de.techdev.trackr.domain.company.ContactPerson;
+import de.techdev.trackr.domain.employee.Employee;
+import de.techdev.trackr.domain.employee.expenses.TravelExpense;
+import de.techdev.trackr.domain.employee.expenses.reports.Report;
+import de.techdev.trackr.domain.employee.expenses.reports.comments.Comment;
+import de.techdev.trackr.domain.employee.sickdays.SickDays;
+import de.techdev.trackr.domain.employee.vacation.VacationRequest;
+import de.techdev.trackr.domain.project.Project;
+import de.techdev.trackr.domain.project.billtimes.BillableTime;
+import de.techdev.trackr.domain.project.invoice.Invoice;
+import de.techdev.trackr.domain.project.worktimes.WorkTime;
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.core.convert.support.ConfigurableConversionService;
+import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
+import org.springframework.data.rest.core.event.ValidatingRepositoryEventListener;
+import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurerAdapter;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+@Configuration
+public class ApiRepositoryRestConfiguration extends RepositoryRestConfigurerAdapter {
+
+    @Override
+    public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {
+        config.exposeIdsFor(Employee.class, Company.class, ContactPerson.class,
+                Address.class, Project.class, WorkTime.class, BillableTime.class, VacationRequest.class, TravelExpense.class,
+                Report.class, Comment.class, Invoice.class, SickDays.class);
+        config.setReturnBodyOnUpdate(true);
+        config.setReturnBodyOnCreate(true);
+    }
+
+    @Override
+    public void configureConversionService(ConfigurableConversionService conversionService) {
+        super.configureConversionService(conversionService);
+        conversionService.addConverter(dateConverter());
+    }
+
+    @Bean
+    public DateConverter dateConverter() {
+        return new DateConverter();
+    }
+
+    /**
+     * Add the validator to spring data rest.
+     */
+    @Override
+    public void configureValidatingRepositoryEventListener(ValidatingRepositoryEventListener validatingListener) {
+        validatingListener.addValidator("beforeSave", validator());
+        validatingListener.addValidator("beforeCreate", validator());
+    }
+
+    /**
+     * Custom validator that extracts messages with locale. Used by spring-data-rest.
+     */
+    @Bean
+    public LocalValidatorFactoryBean validator() {
+        LocalValidatorFactoryBean localValidatorFactoryBean = new LocalValidatorFactoryBean();
+        localValidatorFactoryBean.setValidationMessageSource(messageSource());
+        return localValidatorFactoryBean;
+    }
+
+    /**
+     * Load all messages, reload when locale changes.
+     */
+    @Bean
+    public MessageSource messageSource() {
+        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+        messageSource.setBasenames("classpath:org/hibernate/validator/ValidationMessages", "classpath:/i18n/validation/messages");
+        return messageSource;
+    }
+
+}

--- a/src/main/java/de/techdev/trackr/core/web/api/ApiWebMvcConfiguration.java
+++ b/src/main/java/de/techdev/trackr/core/web/api/ApiWebMvcConfiguration.java
@@ -2,30 +2,12 @@ package de.techdev.trackr.core.web.api;
 
 import de.techdev.trackr.core.web.converters.DateConverter;
 import de.techdev.trackr.domain.common.EmployeeSettingsLocaleResolver;
-import de.techdev.trackr.domain.company.Address;
-import de.techdev.trackr.domain.company.Company;
-import de.techdev.trackr.domain.company.ContactPerson;
-import de.techdev.trackr.domain.employee.Employee;
-import de.techdev.trackr.domain.employee.expenses.TravelExpense;
-import de.techdev.trackr.domain.employee.expenses.reports.Report;
-import de.techdev.trackr.domain.employee.expenses.reports.comments.Comment;
-import de.techdev.trackr.domain.employee.sickdays.SickDays;
-import de.techdev.trackr.domain.employee.vacation.VacationRequest;
-import de.techdev.trackr.domain.project.Project;
-import de.techdev.trackr.domain.project.billtimes.BillableTime;
-import de.techdev.trackr.domain.project.invoice.Invoice;
-import de.techdev.trackr.domain.project.worktimes.WorkTime;
-import org.springframework.context.MessageSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.support.ReloadableResourceBundleMessageSource;
-import org.springframework.core.convert.support.ConfigurableConversionService;
-import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
-import org.springframework.data.rest.core.event.ValidatingRepositoryEventListener;
 import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration;
 import org.springframework.data.rest.webmvc.support.RepositoryEntityLinks;
 import org.springframework.format.FormatterRegistry;
-import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.LocaleResolver;
 
@@ -34,23 +16,18 @@ import java.util.List;
 @Configuration
 public class ApiWebMvcConfiguration extends RepositoryRestMvcConfiguration {
 
-    @Override
-    protected void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {
-        config.exposeIdsFor(Employee.class, Company.class, ContactPerson.class,
-                Address.class, Project.class, WorkTime.class, BillableTime.class, VacationRequest.class, TravelExpense.class,
-                Report.class, Comment.class, Invoice.class, SickDays.class);
-        config.setReturnBodyOnUpdate(true);
-        config.setReturnBodyOnCreate(true);
-    }
+    @Autowired
+    private DateConverter dateConverter;
 
     /**
-     * The self HREF for entities contains {?projection} to indiciate the parameter is available, but we don't want that.
-     * The {@link de.techdev.trackr.core.web.api.RepositoryEntityLinksWithoutProjection} switches {?projection} off.
+     * The self HREF for entities contains {?projection} to indicate the parameter is available, but we don't want that.
+     * The {@link RepositoryEntityLinksWithoutProjection} switches {?projection} off.
      */
     @Override
     @Bean
     public RepositoryEntityLinks entityLinks() {
-        return new RepositoryEntityLinksWithoutProjection(repositories(), resourceMappings(), config(), pageableResolver(), backendIdConverterRegistry());
+        ArgumentResolverPagingAndSortingTemplateVariables variables = new ArgumentResolverPagingAndSortingTemplateVariables(this.pageableResolver(), this.sortResolver());
+        return new RepositoryEntityLinksWithoutProjection(repositories(), resourceMappings(), config(), variables, backendIdConverterRegistry());
     }
 
     @Bean
@@ -58,23 +35,14 @@ public class ApiWebMvcConfiguration extends RepositoryRestMvcConfiguration {
         return new EmployeeSettingsLocaleResolver();
     }
 
-    @Bean
-    public DateConverter dateConverter() {
-        return new DateConverter();
-    }
-
-    @Override
-    protected void configureConversionService(ConfigurableConversionService conversionService) {
-        super.configureConversionService(conversionService);
-        conversionService.addConverter(dateConverter());
-    }
-
-    /**
-     * Somehow the "normal" Spring MVC (not spring-data-rest) does not use the converter registered in {@link #configureConversionService} so we have to register it again.
-     */
     @Override
     public void addFormatters(FormatterRegistry registry) {
-        registry.addConverter(dateConverter());
+        // super call is needed so the DomainClassConverter is used for linked resources
+        // (e.g. companies/0/address). The super class will configure the DomainClassConverter correctly only with this
+        // super call.
+        super.addFormatters(registry);
+        // We need to add the converter so non-Spring-Data-REST calls also use it.
+        registry.addConverter(dateConverter);
     }
 
     /**
@@ -89,35 +57,6 @@ public class ApiWebMvcConfiguration extends RepositoryRestMvcConfiguration {
     public void configureHandlerExceptionResolvers(List<HandlerExceptionResolver> exceptionResolvers) {
         exceptionResolvers.add(jsonMappingHandlerExceptionResolver());
         super.configureHandlerExceptionResolvers(exceptionResolvers);
-    }
-
-    /**
-     * Load all messages, reload when locale changes.
-     */
-    @Bean
-    public MessageSource messageSource() {
-        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
-        messageSource.setBasenames("classpath:org/hibernate/validator/ValidationMessages", "classpath:/i18n/validation/messages");
-        return messageSource;
-    }
-
-    /**
-     * Add the validator to spring data rest.
-     */
-    @Override
-    protected void configureValidatingRepositoryEventListener(ValidatingRepositoryEventListener validatingListener) {
-        validatingListener.addValidator("beforeSave", validator());
-        validatingListener.addValidator("beforeCreate", validator());
-    }
-
-    /**
-     * Custom validator that extracts messages with locale. Used by spring-data-rest.
-     */
-    @Bean
-    public LocalValidatorFactoryBean validator() {
-        LocalValidatorFactoryBean localValidatorFactoryBean = new LocalValidatorFactoryBean();
-        localValidatorFactoryBean.setValidationMessageSource(messageSource());
-        return localValidatorFactoryBean;
     }
 
 }

--- a/src/main/java/de/techdev/trackr/core/web/api/ArgumentResolverPagingAndSortingTemplateVariables.java
+++ b/src/main/java/de/techdev/trackr/core/web/api/ArgumentResolverPagingAndSortingTemplateVariables.java
@@ -1,0 +1,57 @@
+package de.techdev.trackr.core.web.api;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.rest.webmvc.support.PagingAndSortingTemplateVariables;
+import org.springframework.data.web.HateoasPageableHandlerMethodArgumentResolver;
+import org.springframework.data.web.HateoasSortHandlerMethodArgumentResolver;
+import org.springframework.hateoas.TemplateVariables;
+import org.springframework.util.Assert;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Copy from Spring because thankfully they made it package protected. Nice!
+ *
+ * @deprecated See {@link RepositoryEntityLinksWithoutProjection}
+ */
+@Deprecated
+class ArgumentResolverPagingAndSortingTemplateVariables implements PagingAndSortingTemplateVariables {
+    private static final Set<Class<?>> SUPPORTED_TYPES = Collections.unmodifiableSet(new HashSet(Arrays.asList(new Class[]{Pageable.class, Sort.class})));
+    private final HateoasPageableHandlerMethodArgumentResolver pagingResolver;
+    private final HateoasSortHandlerMethodArgumentResolver sortResolver;
+
+    public ArgumentResolverPagingAndSortingTemplateVariables(HateoasPageableHandlerMethodArgumentResolver pagingResolver, HateoasSortHandlerMethodArgumentResolver sortResolver) {
+        Assert.notNull(pagingResolver, "HateoasPageableHandlerMethodArgumentResolver must not be null!");
+        Assert.notNull(sortResolver, "HateoasSortHandlerMethodArgumentResolver must not be null!");
+        this.pagingResolver = pagingResolver;
+        this.sortResolver = sortResolver;
+    }
+
+    public TemplateVariables getPaginationTemplateVariables(MethodParameter parameter, UriComponents components) {
+        return this.pagingResolver.getPaginationTemplateVariables(parameter, components);
+    }
+
+    public TemplateVariables getSortTemplateVariables(MethodParameter parameter, UriComponents template) {
+        return this.sortResolver.getSortTemplateVariables(parameter, template);
+    }
+
+    public void enhance(UriComponentsBuilder builder, MethodParameter parameter, Object value) {
+        if(value instanceof Pageable) {
+            this.pagingResolver.enhance(builder, parameter, value);
+        } else if(value instanceof Sort) {
+            this.sortResolver.enhance(builder, parameter, value);
+        }
+
+    }
+
+    public boolean supportsParameter(MethodParameter parameter) {
+        return SUPPORTED_TYPES.contains(parameter.getParameterType());
+    }
+}

--- a/src/main/java/de/techdev/trackr/core/web/api/ExceptionHandlers.java
+++ b/src/main/java/de/techdev/trackr/core/web/api/ExceptionHandlers.java
@@ -2,6 +2,7 @@ package de.techdev.trackr.core.web.api;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.data.rest.core.RepositoryConstraintViolationException;
 import org.springframework.data.rest.webmvc.support.RepositoryConstraintViolationExceptionMessage;
@@ -21,8 +22,12 @@ import static org.springframework.http.HttpStatus.CONFLICT;
 @Slf4j
 public class ExceptionHandlers {
 
+    private final MessageSourceAccessor messageSourceAccessor;
+
     @Autowired
-    private MessageSourceAccessor messageSourceAccessor;
+    public ExceptionHandlers(MessageSource messageSource) {
+        this.messageSourceAccessor = new MessageSourceAccessor(messageSource);
+    }
 
     /**
      * This exception handler <i>should</i> handle violations of unique constraints.

--- a/src/main/java/de/techdev/trackr/core/web/api/RepositoryEntityLinksWithoutProjection.java
+++ b/src/main/java/de/techdev/trackr/core/web/api/RepositoryEntityLinksWithoutProjection.java
@@ -5,8 +5,8 @@ import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.core.mapping.ResourceMappings;
 import org.springframework.data.rest.core.mapping.ResourceMetadata;
 import org.springframework.data.rest.webmvc.spi.BackendIdConverter;
+import org.springframework.data.rest.webmvc.support.PagingAndSortingTemplateVariables;
 import org.springframework.data.rest.webmvc.support.RepositoryEntityLinks;
-import org.springframework.data.web.HateoasPageableHandlerMethodArgumentResolver;
 import org.springframework.hateoas.Link;
 import org.springframework.plugin.core.PluginRegistry;
 import org.springframework.util.Assert;
@@ -16,7 +16,10 @@ import java.io.Serializable;
 /**
  * Overrides the {@link #linkToSingleResource(Class, Object)} method to not include {?projection}.
  * @author Moritz Schulze
+ * @deprecated We really should make the frontend not rely on this and just remove it all together. For the migration to
+ *             Spring Boot 1.3.3 it's left in so the REST API is as before as much as possible.
  */
+@Deprecated
 public class RepositoryEntityLinksWithoutProjection extends RepositoryEntityLinks {
 
     private final ResourceMappings mappings;
@@ -28,11 +31,11 @@ public class RepositoryEntityLinksWithoutProjection extends RepositoryEntityLink
      * @param repositories must not be {@literal null}.
      * @param mappings     must not be {@literal null}.
      * @param config       must not be {@literal null}.
-     * @param resolver     must not be {@literal null}.
+     * @param variables     must not be {@literal null}.
      * @param idConverters must not be {@literal null}.
      */
-    public RepositoryEntityLinksWithoutProjection(Repositories repositories, ResourceMappings mappings, RepositoryRestConfiguration config, HateoasPageableHandlerMethodArgumentResolver resolver, PluginRegistry<BackendIdConverter, Class<?>> idConverters) {
-        super(repositories, mappings, config, resolver, idConverters);
+    public RepositoryEntityLinksWithoutProjection(Repositories repositories, ResourceMappings mappings, RepositoryRestConfiguration config, PagingAndSortingTemplateVariables variables, PluginRegistry<BackendIdConverter, Class<?>> idConverters) {
+        super(repositories, mappings, config, variables, idConverters);
         this.mappings = mappings;
         this.idConverters = idConverters;
     }
@@ -40,8 +43,7 @@ public class RepositoryEntityLinksWithoutProjection extends RepositoryEntityLink
     @Override
     public Link linkToSingleResource(Class<?> type, Object id) {
         Assert.isInstanceOf(Serializable.class, id, "Id must be assignable to Serializable!");
-
-        ResourceMetadata metadata = mappings.getMappingFor(type);
+        ResourceMetadata metadata = mappings.getMetadataFor(type);
         String mappedId = idConverters.getPluginFor(type, BackendIdConverter.DefaultIdConverter.INSTANCE).toRequestId((Serializable) id, type);
         return linkFor(type).slash(mappedId).withRel(metadata.getItemResourceRel());
     }

--- a/src/main/java/de/techdev/trackr/domain/company/CompanyEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/company/CompanyEventHandler.java
@@ -34,6 +34,6 @@ public class CompanyEventHandler {
 
     @HandleBeforeLinkDelete
     @PreAuthorize("hasRole('ROLE_SUPERVISOR')")
-    public void beforeDeleteContactPerson(Company company) {
+    public void beforeDeleteContactPerson(Company company, Object contactPerson) {
     }
 }

--- a/src/main/java/de/techdev/trackr/domain/company/ContactPersonEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/company/ContactPersonEventHandler.java
@@ -33,7 +33,7 @@ public class ContactPersonEventHandler {
 
     @HandleBeforeLinkDelete
     @PreAuthorize("denyAll()")
-    public void checkLinkDeleteAuthority(ContactPerson contactPerson) {
+    public void checkLinkDeleteAuthority(ContactPerson contactPerson, Object linkedEntity) {
         // only security check
     }
 }

--- a/src/main/java/de/techdev/trackr/domain/employee/EmployeeEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/EmployeeEventHandler.java
@@ -37,7 +37,7 @@ public class EmployeeEventHandler {
 
     @HandleBeforeLinkDelete
     @PreAuthorize("denyAll()")
-    public void deleteCredentialForbidden(Employee employee) {
+    public void deleteCredentialForbidden(Employee employee, Object credential) {
         //deny all, cannot be called
     }
 }

--- a/src/main/java/de/techdev/trackr/domain/employee/expenses/TravelExpenseEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/expenses/TravelExpenseEventHandler.java
@@ -31,7 +31,7 @@ public class TravelExpenseEventHandler {
 
     @HandleBeforeLinkDelete
     @PreAuthorize("denyAll()")
-    public void denyLinkDelete(TravelExpense travelExpense) {
+    public void denyLinkDelete(TravelExpense travelExpense, Object linkedEntity) {
         //links are not deletable.
     }
 

--- a/src/main/java/de/techdev/trackr/domain/employee/expenses/TravelExpenseRepository.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/expenses/TravelExpenseRepository.java
@@ -2,6 +2,7 @@ package de.techdev.trackr.domain.employee.expenses;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.rest.core.annotation.RestResource;
+import org.springframework.security.access.prepost.PostAuthorize;
 
 /**
  * @author Moritz Schulze
@@ -13,6 +14,6 @@ public interface TravelExpenseRepository extends CrudRepository<TravelExpense, L
     Iterable<TravelExpense> findAll();
 
     @Override
-    @RestResource(exported = false)
+    @PostAuthorize("returnObject?.report.employee.email == principal?.username")
     TravelExpense findOne(Long aLong);
 }

--- a/src/main/java/de/techdev/trackr/domain/employee/expenses/reports/ReportEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/expenses/reports/ReportEventHandler.java
@@ -37,7 +37,7 @@ public class ReportEventHandler {
 
     @HandleBeforeLinkDelete
     @PreAuthorize("hasRole('ROLE_SUPERVISOR') or #travelExpenseReport.employee.email == principal?.username")
-    public void checkLinkDeleteAuthority(Report travelExpenseReport) {
+    public void checkLinkDeleteAuthority(Report travelExpenseReport, Object linkedEntity) {
         if(travelExpenseReport.getEmployee() == null) {
             throw new AccessDeniedException("Employee is not deletable on a travel expense report.");
         }

--- a/src/main/java/de/techdev/trackr/domain/employee/expenses/reports/comments/CommentEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/expenses/reports/comments/CommentEventHandler.java
@@ -29,7 +29,7 @@ public class CommentEventHandler {
 
     @HandleBeforeLinkDelete
     @PreAuthorize("denyAll()")
-    public void checkLinkDeleteAuthority(Comment comment) {
+    public void checkLinkDeleteAuthority(Comment comment, Object linkedEntity) {
         //deny all
     }
 }

--- a/src/main/java/de/techdev/trackr/domain/employee/sickdays/SickDaysEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/sickdays/SickDaysEventHandler.java
@@ -36,7 +36,7 @@ public class SickDaysEventHandler {
 
     @HandleBeforeLinkDelete
     @PreAuthorize("denyAll()")
-    public void checkLiknkSaveAuthority(SickDays sickDays) {
+    public void checkLinkSaveAuthority(SickDays sickDays, Object linkedEntity) {
         //deny all
     }
 }

--- a/src/main/java/de/techdev/trackr/domain/employee/vacation/VacationRequestEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/employee/vacation/VacationRequestEventHandler.java
@@ -60,7 +60,7 @@ public class VacationRequestEventHandler {
 
     @HandleBeforeLinkDelete
     @PreAuthorize("denyAll()")
-    public void denyLinks(VacationRequest vacationRequest) {
+    public void denyLinks(VacationRequest vacationRequest, Object linkedEntity) {
         //deny all, cannot be called
     }
 

--- a/src/main/java/de/techdev/trackr/domain/project/ProjectEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/project/ProjectEventHandler.java
@@ -32,6 +32,6 @@ public class ProjectEventHandler {
 
     @HandleBeforeLinkDelete
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    public void checkLinkDeletePermission(Project project) {
+    public void checkLinkDeletePermission(Project project, Object linkedEntity) {
     }
 }

--- a/src/main/java/de/techdev/trackr/domain/project/billtimes/BillableTimeEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/project/billtimes/BillableTimeEventHandler.java
@@ -32,6 +32,6 @@ public class BillableTimeEventHandler {
 
     @HandleBeforeLinkDelete
     @PreAuthorize("denyAll()")
-    public void checkLinkDeleteAuthority(BillableTime billableTime) {
+    public void checkLinkDeleteAuthority(BillableTime billableTime, Object linkedEntity) {
     }
 }

--- a/src/main/java/de/techdev/trackr/domain/project/worktimes/WorkTimeEventHandler.java
+++ b/src/main/java/de/techdev/trackr/domain/project/worktimes/WorkTimeEventHandler.java
@@ -34,7 +34,7 @@ public class WorkTimeEventHandler {
 
     @HandleBeforeLinkDelete
     @PreAuthorize("denyAll()")
-    public void checkDeleteLinkAuthority(WorkTime workTime) {
+    public void checkDeleteLinkAuthority(WorkTime workTime, Object linkedEntity) {
         //deny all, cannot be called
     }
 }

--- a/src/main/resources/logback-file.xml
+++ b/src/main/resources/logback-file.xml
@@ -3,10 +3,10 @@
     <property name="charset" value="UTF-8"/>
     <property name="pattern" value="%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
 
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>/var/log/trackr-backend.log</file>
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/opt/techdev/trackr-backend/logs/trackr-backend.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>/var/log/trackr-backend_%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <fileNamePattern>/opt/techdev/trackr-backend/logs/trackr-backend_%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <maxFileSize>5MB</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>

--- a/src/test/java/de/techdev/trackr/domain/employee/expenses/TravelExpenseResourceSecurityTest.java
+++ b/src/test/java/de/techdev/trackr/domain/employee/expenses/TravelExpenseResourceSecurityTest.java
@@ -29,9 +29,14 @@ public class TravelExpenseResourceSecurityTest extends AbstractDomainResourceSec
     }
 
     @Test
-    @OAuthRequest("ROLE_ADMIN")
-    public void oneNotExported() throws Exception {
-        assertThat(one(0L), isMethodNotAllowed());
+    @OAuthRequest(value = "ROLE_ADMIN", username = "admin@techdev.de")
+    public void oneForbiddenForOther() throws Exception {
+        assertThat(one(0L), isForbidden());
+    }
+
+    @Test
+    public void oneAllowedForSelf() throws Exception {
+        assertThat(one(0L), isAccessible());
     }
 
     @Test

--- a/src/test/java/de/techdev/trackr/domain/employee/expenses/report/ReportResourceSecurityTest.java
+++ b/src/test/java/de/techdev/trackr/domain/employee/expenses/report/ReportResourceSecurityTest.java
@@ -109,6 +109,7 @@ public class ReportResourceSecurityTest extends AbstractDomainResourceSecurityTe
     }
 
     @Test
+    // TODO: Not a really useful test as expenses are never added this way (they need to have the report first...)
     public void addTravelExpenseAllowedForSelf() throws Exception {
         assertThat(updateLink(0L, "expenses", "/travelExpenses/0"), isNoContent());
     }

--- a/src/test/java/de/techdev/trackr/domain/employee/sickdays/SickDaysResourceSecurityTest.java
+++ b/src/test/java/de/techdev/trackr/domain/employee/sickdays/SickDaysResourceSecurityTest.java
@@ -82,7 +82,7 @@ public class SickDaysResourceSecurityTest extends AbstractDomainResourceSecurity
 
     @Test
     public void findByEmployeeIsAllowedForEmployee() throws Exception {
-        assertThat(oneUrl("/sickDays/search/findByEmployee?employee=0"), isAccessible());
+        assertThat(oneUrl("/sickDays/search/findByEmployee?employee=/employees/0"), isAccessible());
     }
 
     @Test

--- a/src/test/java/de/techdev/trackr/domain/employee/vacation/VacationRequestResourceSecurityTest.java
+++ b/src/test/java/de/techdev/trackr/domain/employee/vacation/VacationRequestResourceSecurityTest.java
@@ -42,14 +42,14 @@ public class VacationRequestResourceSecurityTest extends AbstractDomainResourceS
 
     @Test
     public void findByEmployeeOrderByStartDateAscAllowedForEmployee() throws Exception {
-        ResponseEntity<String> response = restTemplate.getForEntity(host + "/vacationRequests/search/findByEmployeeOrderByStartDateAsc?employee=0", String.class);
+        ResponseEntity<String> response = restTemplate.getForEntity(host + "/vacationRequests/search/findByEmployeeOrderByStartDateAsc?employee=/employees/0", String.class);
         assertThat(response, isAccessible());
     }
 
     @Test
     @OAuthRequest(value = "ROLE_SUPERVISOR", username = "supervisor@techdev.de")
     public void findByEmployeeOrderByStartDateAscAllowedForSupervisor() throws Exception {
-        ResponseEntity<String> response = restTemplate.getForEntity(host + "/vacationRequests/search/findByEmployeeOrderByStartDateAsc?employee=0", String.class);
+        ResponseEntity<String> response = restTemplate.getForEntity(host + "/vacationRequests/search/findByEmployeeOrderByStartDateAsc?employee=/employees/0", String.class);
         assertThat(response, isAccessible());
     }
 

--- a/src/test/java/de/techdev/trackr/domain/project/worktimes/WorkTimeResourceSecurityTest.java
+++ b/src/test/java/de/techdev/trackr/domain/project/worktimes/WorkTimeResourceSecurityTest.java
@@ -126,7 +126,7 @@ public class WorkTimeResourceSecurityTest extends AbstractDomainResourceSecurity
     @Test
     public void findByEmployeeAndDateOrderByStartTimeAscAllowedForOwner() throws Exception {
         ResponseEntity<String> response = restTemplate
-                .getForEntity(host + "/workTimes/search/findByEmployeeAndDateOrderByStartTimeAsc?employee=0&date=2014-01-01", String.class);
+                .getForEntity(host + "/workTimes/search/findByEmployeeAndDateOrderByStartTimeAsc?employee=/employees/0&date=2014-01-01", String.class);
         assertThat(response, isAccessible());
     }
 
@@ -134,7 +134,7 @@ public class WorkTimeResourceSecurityTest extends AbstractDomainResourceSecurity
     @OAuthRequest(value = "ROLE_SUPERVISOR", username = "supervisor@techdev.de")
     public void findByEmployeeAndDateOrderByStartTimeAscAllowedForSupervisor() throws Exception {
         ResponseEntity<String> response = restTemplate
-                .getForEntity(host + "/workTimes/search/findByEmployeeAndDateOrderByStartTimeAsc?employee=0&date=2014-01-01", String.class);
+                .getForEntity(host + "/workTimes/search/findByEmployeeAndDateOrderByStartTimeAsc?employee=/employees/0&date=2014-01-01", String.class);
         assertThat(response, isAccessible());
     }
 
@@ -157,7 +157,7 @@ public class WorkTimeResourceSecurityTest extends AbstractDomainResourceSecurity
     @Test
     public void findByEmployeeAndDateBetweenOrderByDateAscStartTimeAscAllowedForOwner() throws Exception {
         ResponseEntity<String> response = restTemplate
-                .getForEntity(host + "/workTimes/search/findByEmployeeAndDateBetweenOrderByDateAscStartTimeAsc?employee=0&start=2014-01-01&end=2014-01-31", String.class);
+                .getForEntity(host + "/workTimes/search/findByEmployeeAndDateBetweenOrderByDateAscStartTimeAsc?employee=/employees/0&start=2014-01-01&end=2014-01-31", String.class);
         assertThat(response, isAccessible());
     }
 
@@ -165,7 +165,7 @@ public class WorkTimeResourceSecurityTest extends AbstractDomainResourceSecurity
     @OAuthRequest(value = "ROLE_SUPERVISOR", username = "supervisor@techdev.de")
     public void findByEmployeeAndDateBetweenOrderByDateAscStartTimeAscAllowedForSupervisor() throws Exception {
         ResponseEntity<String> response = restTemplate
-                .getForEntity(host + "/workTimes/search/findByEmployeeAndDateBetweenOrderByDateAscStartTimeAsc?employee=0&start=2014-01-01&end=2014-01-31", String.class);
+                .getForEntity(host + "/workTimes/search/findByEmployeeAndDateBetweenOrderByDateAscStartTimeAsc?employee=/employees/0&start=2014-01-01&end=2014-01-31", String.class);
         assertThat(response, isAccessible());
     }
 
@@ -179,7 +179,7 @@ public class WorkTimeResourceSecurityTest extends AbstractDomainResourceSecurity
     @OAuthRequest(username = "someone.else@techdev.de")
     public void findByEmployeeAndDateBetweenOrderByDateAscStartTimeAscForbiddenForOther() throws Exception {
         ResponseEntity<String> response = restTemplate
-                .getForEntity(host + "/workTimes/search/findByEmployeeAndDateBetweenOrderByDateAscStartTimeAsc?employee=0&start=2014-01-01&end=2014-01-31", String.class);
+                .getForEntity(host + "/workTimes/search/findByEmployeeAndDateBetweenOrderByDateAscStartTimeAsc?employee=/employees/0&start=2014-01-01&end=2014-01-31", String.class);
         assertThat(response, isForbidden());
     }
 
@@ -193,7 +193,7 @@ public class WorkTimeResourceSecurityTest extends AbstractDomainResourceSecurity
     @OAuthRequest(username = "someone.else@techdev.de")
     public void findByEmployeeAndDateOrderByStartTimeAscForbiddenForOther() throws Exception {
         ResponseEntity<String> response = restTemplate
-                .getForEntity(host + "/workTimes/search/findByEmployeeAndDateOrderByStartTimeAsc?employee=0&date=2014-01-01", String.class);
+                .getForEntity(host + "/workTimes/search/findByEmployeeAndDateOrderByStartTimeAsc?employee=/employees/0&date=2014-01-01", String.class);
         assertThat(response, isForbidden());
     }
 
@@ -201,14 +201,14 @@ public class WorkTimeResourceSecurityTest extends AbstractDomainResourceSecurity
     @OAuthRequest(value = "ROLE_SUPERVISOR")
     public void findByProjectAndDateBetweenOrderByDateAscStartTimeAscAllowedForSupervisor() throws Exception {
         ResponseEntity<String> response = restTemplate
-                .getForEntity(host + "/workTimes/search/findByProjectAndDateBetweenOrderByDateAscStartTimeAsc?project=0&start=2014-01-01&end=2014-01-31", String.class);
+                .getForEntity(host + "/workTimes/search/findByProjectAndDateBetweenOrderByDateAscStartTimeAsc?project=/projects/0&start=2014-01-01&end=2014-01-31", String.class);
         assertThat(response, isAccessible());
     }
 
     @Test
     public void findByProjectAndDateBetweenOrderByDateAscStartTimeAscForbiddenForEmployee() throws Exception {
         ResponseEntity<String> response = restTemplate
-                .getForEntity(host + "/workTimes/search/findByProjectAndDateBetweenOrderByDateAscStartTimeAsc?project=0&start=2014-01-01&end=2014-01-31", String.class);
+                .getForEntity(host + "/workTimes/search/findByProjectAndDateBetweenOrderByDateAscStartTimeAsc?project=/projects/0&start=2014-01-01&end=2014-01-31", String.class);
         assertThat(response, isForbidden());
     }
 

--- a/src/test/resources/de/techdev/trackr/domain/employee/expenses/report/resourceTest.sql
+++ b/src/test/resources/de/techdev/trackr/domain/employee/expenses/report/resourceTest.sql
@@ -16,3 +16,6 @@ INSERT INTO travelExpenseReport (id, version, employee_id, status, submissionDat
 
 INSERT INTO travelExpenseReport (id, version, employee_id, status, submissionDate, debitor_id)
  VALUES (1, 0, 0, 'SUBMITTED', '2015-01-25 09:30:21', 0);
+
+INSERT INTO travelexpense (id, cost, fromdate, submissiondate, todate, type, vat, version, report_id, comment, paid)
+  VALUES (0, 100, '2015-01-01', '2015-02-01 13:41:13', '2015-02-13', 'TAXI', 13, 0, 0, 'Comment', false);


### PR DESCRIPTION
Updates dependencies to Spring Boot 1.3.3 and Spring Integration Mail 4.2.5.
The `executable` flag of the gradle plugin config was added so the service
script is included.

These fixes were needed:

* The new Spring Data REST version splits some configuration in separate
  files.

  So we now have the ApiWebMvcConfiguration and the
  ApiRepositoryRestConfiguration.

  The custom `entityLinks` `RepositoryEntityLinks` class we used before to
  avoid having "{?projection}" in the JSON output in self HREFs is
  different from before and needed the copying of a package protected
  Spring class. Since I'm unsure if we even need it, it's marked
  deprecated.

  The `DomainClassConverter` bean is now only exposed by Spring if
  `addFormatters` in the ApiWebMvcConfiguration calls `super`. If the call
  is left out, linked resources (e.g. companies/0/address) don't work as expected.

* Spring does not expose a bean of type `MessageSourceAccessor` anymore so
  it needs to be created from the `MessageSource` directly in `ExceptionHandlers`.

* For the DELETE method to work on Spring Data REST repositories the
  `findOne` method must be exported in the new version.

  This had to be done in the TravelExpenseRepository as we need
  DELETE (but not findOne). To still have some restrictions security was
  added so only the owning employee of a travel expense can access
  it. `denyAll` would not work since the repository method (not via REST!)
  is still needed.

* TRACKR-297 Link delete handlers take two arguments

  `@HandleBeforeLinkDelete` methods in `@RepositoryEventHandler` classes
  now need to take two arguments (the deleted link as the second one).

* Finder methods exported by Spring Data REST now need references to
  entities as URIs instead of just ids. So
  `search/findByEmployee?employee=0` becomes
  `search/findByEmployee?employee=/employees/0`.