### PR TITLE
Bump Spring Security OAuth2 version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
     // not included in boot
     compile "org.springframework.integration:spring-integration-mail:4.2.5.RELEASE"
-    compile "org.springframework.security.oauth:spring-security-oauth2:2.0.2.RELEASE"
+    compile "org.springframework.security.oauth:spring-security-oauth2:2.0.11.RELEASE"
 
     compile "com.h2database:h2"
     compile "postgresql:postgresql:9.1-901.jdbc4"


### PR DESCRIPTION
Since we ran into a serialization issue with using a newer version in the [portal](https://github.com/techdev-solutions/techdev-portal), this updates Spring Security OAuth2 to the same version.
